### PR TITLE
Patches to the RP4 Build script

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,18 @@
+#
+# Configuration for Raspberry PI building
+#
+
+#
+## Repository configuration
+#
+
+### List of repositories to check out
+repositories=""
+
+### Configuration of individual repositories
+
+#directives:
+#<repo>="<some url>"
+#<repo>_branches="<list of branches to check out, MUST include at least one!>"
+#<repo>_commit_id="<specific commit to check out>"
+

--- a/config
+++ b/config
@@ -7,7 +7,7 @@
 #
 
 ### List of repositories to check out
-repositories=""
+repositories="edk2 edk2-platforms edk2-non-osi tf-a"
 
 ### Configuration of individual repositories
 
@@ -19,4 +19,16 @@ repositories=""
 # NOTE: <repo>_branches settings MUST be present and MUST include at least one
 # branch.  If more than one branch is listed, the branch for the RP4 must be
 # first and the branch for the RP3 must be last.
+
+edk2="https://github.com/pftf/edk2.git"
+edk2_branches="pi4_dev2"
+
+edk2_platforms="https://github.com/pftf/edk2-platforms.git"
+edk2_platforms_branches="pi4_dev2 master"
+
+edk2_non_osi="https://github.com/pftf/edk2-non-osi.git"
+edk2_non_osi_branches="pi4_dev1 master"
+
+tf_a="https://github.com/ARM-software/arm-trusted-firmware.git"
+tf_a_branches="master"
 

--- a/config
+++ b/config
@@ -13,6 +13,10 @@ repositories=""
 
 #directives:
 #<repo>="<some url>"
-#<repo>_branches="<list of branches to check out, MUST include at least one!>"
+#<repo>_branches="<list of branches to check out>"
 #<repo>_commit_id="<specific commit to check out>"
+
+# NOTE: <repo>_branches settings MUST be present and MUST include at least one
+# branch.  If more than one branch is listed, the branch for the RP4 must be
+# first and the branch for the RP3 must be last.
 

--- a/lampone_build.sh
+++ b/lampone_build.sh
@@ -30,7 +30,7 @@ usage()
 error()
 {
     echo
-    echo $0 error: $@
+    echo $0 error: $@ 1>&2
     echo
     exit
 }

--- a/lampone_build.sh
+++ b/lampone_build.sh
@@ -16,6 +16,10 @@
 # For Ubuntu, outside of make, python3 and a local toolchain:
 # $ apt-get update && apt-get install -y uuid-dev iasl
 #
+
+# Fail if a command fails
+set -e
+
 usage()
 {
     echo

--- a/lampone_build.sh
+++ b/lampone_build.sh
@@ -20,6 +20,9 @@
 # Fail if a command fails
 set -e
 
+# Load configuration
+. $(dirname $(which "$0"))/config
+
 usage()
 {
     echo
@@ -58,6 +61,8 @@ build_tfa()
         TARGETS="all"
         TARGET_SRC="${PWD}/build/${PLAT}/release/bl31.bin"
     fi
+
+    git submodule update --init
 
     make PLAT=${TFA_PLAT} PRELOADED_BL33_BASE=${BL33_BASE} RPI3_PRELOADED_DTB_BASE=${DTB_BASE} SUPPORT_VFP=1 RPI3_USE_UEFI_MAP=1 DEBUG=0 V=1 ${TARGETS}
 
@@ -183,28 +188,56 @@ if [ ! -d "gcc5" ]; then
 fi
 export GCC5_AARCH64_PREFIX=${BASEDIR}/gcc5/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
 
-if [ ! -d "edk2" ]; then
-    git clone https://github.com/ardbiesheuvel/edk2 edk2
-    pushd edk2
-    #
-    # Known good SHA/branch for platforms/non-osi forks below.
-    #
-    git checkout remotes/origin/rpi4
-    git submodule update --init
-    popd
-fi
+for dir in $repositories
+do
+	varname="$dir"
+	while [ "${varname%-*}" != "$varname" ]
+	do varname="${varname%%-*}_${varname#*-}"
+	done
 
-if [ ! -d "edk2-platforms" ]; then
-    git clone https://github.com/pftf/edk2-platforms edk2-platforms
-fi
+	url="$(eval echo "\"\$$varname\"")"
 
-if [ ! -d "edk2-non-osi" ]; then
-    git clone https://github.com/pftf/edk2-non-osi edk2-non-osi
-fi
+	branches="$(eval echo "\"\${${varname}_branches:-master}\"")"
 
-if [ ! -d "tf-a" ]; then
-    git clone https://github.com/ARM-software/arm-trusted-firmware tf-a
-fi
+	commit="$(eval echo "\"\${${varname}_commit_id:-}\"")"
+
+	origin="${url#https://github.com/}"
+	origin="${origin%%/*}"
+
+	if [ ! -d "$dir" ]
+	then
+		git clone -o "$origin" -b "${branches%% *}" --single-branch "$url" "$dir"
+		cd "$dir"
+		git remote set-branches "$origin" $branches
+
+		if [ "${branches%% *}" != "${branches}" ]
+		then
+			git fetch -n --multiple "$origin" $branches
+		fi
+
+	else
+		cd "$dir"
+
+		if ! cur=`git remote get-url "$origin" 2>/dev/null`
+		then
+			git remote add "$origin" "$url"
+		elif [ "$cur" != "$url" ]
+		then
+			git remote remove "$origin"-old >/dev/null 2>&1 || true
+			git remote rename "$origin" "$origin"-old >/dev/null 2>&1
+			git remote add "$origin" "$url"
+		fi
+
+		git remote set-branches --add "$origin" $branches
+
+		git fetch -n "$origin" $branches
+	fi
+
+	[ -n "$commit" ] || commit="remotes/$origin/${branches%% *}"
+	git checkout "$commit"
+
+	cd ..
+done
 
 build_tfa
 prep_edk2


### PR DESCRIPTION
Things _I_ was noticing during attempts to build.  Due to the way the lampone_build.sh script works, it will retrieve _all_ branches and _all_ tags from your mirrors of the EDK2 repositories.  Due to the size of those repositories those branches mean a fair bit of bandwidth and disk space.  I've also split the repository settings into a distinct file, so if the know okay EDK2 commit changes that is easier.

If one already has a cross-compiling GCC installed, one might want to use the already installed local cross-GCC.  Though now that I think about it, I recall some issues of differing compiler versions causing some issues (erk).